### PR TITLE
move card into payment object according to the privat documentation

### DIFF
--- a/lib/privat24_api/request/info/info_request.rb
+++ b/lib/privat24_api/request/info/info_request.rb
@@ -15,9 +15,10 @@ module Privat24Api
       Request.new(card_args).send_data_for(MOD, __method__.to_s) do |data|
         data.oper('cmt')
         data.wait('0')
-        data.payment(id: '')
-        data.prop(name: 'cardnum', value: card_args[:card_num])
-        data.prop(name: 'country', value: 'UA')
+        data.payment(id: '') do
+          data.prop(name: 'cardnum', value: card_args[:card_num])
+          data.prop(name: 'country', value: 'UA')
+        end
       end
     end
 


### PR DESCRIPTION
Card should be inside of Payment according to the documentation (https://api.privatbank.ua/#p24/balance)
Bug: balance always returns only the data about merchant's default card, while the card in the request is ignored.
moving the card into payment enables getting balances of any merchant's card.